### PR TITLE
A few bug fixes and improvements for AQ Sync

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 		<dependency>
 			<groupId>gov.usgs.aqcu</groupId>
 			<artifactId>aqcu-data-core</artifactId>
-			<version>0.14-SNAPSHOT</version>
+			<version>1.1.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.mybatis</groupId>

--- a/src/main/java/gov/usgs/wma/gcmrc/service/AqToGdaws.java
+++ b/src/main/java/gov/usgs/wma/gcmrc/service/AqToGdaws.java
@@ -6,7 +6,6 @@ import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,7 +25,6 @@ import gov.usgs.wma.gcmrc.model.TimeSeriesRecord;
 import gov.usgs.wma.gcmrc.util.TimeSeriesUtils;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 
 public class AqToGdaws {
@@ -80,8 +78,8 @@ public class AqToGdaws {
 		this.daysToFetchForNewTimeseries = daysToFetchForNewTimeseries != null ? daysToFetchForNewTimeseries : DEFAULT_DAYS_TO_FETCH_FOR_NEW_TIMESERIES;
 		this.sourceId = sourceId;
 		this.oldSourceId = oldSourceId;
-		this.startTime = startTime != null ? startTime.atZone(ZonedDateTime.now().getZone()) : null;
-		this.endTime = endTime != null ? endTime.atZone(ZonedDateTime.now().getZone()) : null;
+		this.startTime = TimeSeriesUtils.getAsMstDateTime(startTime);
+		this.endTime = TimeSeriesUtils.getAsMstDateTime(endTime);
 		this.tsToPullList = tsToPullList;
 		
 		//If the user is providing any part of a date range to pull then we should NOT update the last pull dates

--- a/src/main/java/gov/usgs/wma/gcmrc/util/TimeSeriesUtils.java
+++ b/src/main/java/gov/usgs/wma/gcmrc/util/TimeSeriesUtils.java
@@ -18,6 +18,9 @@ import gov.usgs.wma.gcmrc.service.Interpolation;
 public class TimeSeriesUtils {
 	private static final Logger LOG = LoggerFactory.getLogger(AutoProcConfigurationLoader.class);
 	
+	/** The TimeZone all data in the project is assumed to be in (Mountain Standard Time, offset of -7 hours.) */
+	public static final ZoneOffset MST_ZONE_OFFSET = ZoneOffset.of("-07:00");
+	
 	public static TimeSeriesRecord getInterpolatedDischarge(List<TimeSeriesRecord> discharge, LocalDateTime targetDateTime, Integer sourceId, Integer groupId, Integer siteId) {
 		Integer[] leftRightIndex = getBracketingPoints(discharge, targetDateTime, new Integer[] { 0, discharge.size()-1}); //start recursive function at the far left and right
 		
@@ -91,13 +94,32 @@ public class TimeSeriesUtils {
 		ZoneOffset newZoneOffset;
 		ZoneOffset oldZoneOffset = ZonedDateTime.from(aqDateTime).getOffset();
 		
-		if (!oldZoneOffset.equals(ZoneOffset.of("-07:00"))){
-			newZoneOffset = ZoneOffset.of("-07:00");
+		if (!oldZoneOffset.equals(MST_ZONE_OFFSET)){
+			newZoneOffset = MST_ZONE_OFFSET;
 			newZonedDateTime = ZonedDateTime.from(aqDateTime).withZoneSameInstant(newZoneOffset);
 			mstDateTime = LocalDateTime.from(newZonedDateTime);
 		} else {
 			mstDateTime = LocalDateTime.from(aqDateTime);
 		}
 		return mstDateTime;
+	}
+	
+	/**
+	 * Tacks on the MST Timezone to a LocalDateTime.
+	 * 
+	 * This method doesn't do much, but it is tricky to understand if adding the
+	 * zone adjusts the time - here it codifies how to do it for the project.
+	 * 
+	 * Returns null for null.
+	 * 
+	 * @param localDateTime
+	 * @return 
+	 */
+	public static ZonedDateTime getAsMstDateTime(LocalDateTime localDateTime) {
+		if (localDateTime != null) {
+			return localDateTime.atZone(MST_ZONE_OFFSET);
+		} else {
+			return null;
+		}
 	}
 }

--- a/src/main/resources/gcmrc-sync-config.properties
+++ b/src/main/resources/gcmrc-sync-config.properties
@@ -46,9 +46,13 @@ default.days.to.fetch.for.new.timeseries: 30
 # timeseries GUIDs. NOTE: Including either a start or end time will stop the
 # "last pull" time information from updating in the database.
 
-# The date & time to start the data pull from. Format (ISO): YYYY-MM-ddTHH:mm:ss
+# The date & time to start the data pull from. Assumed to be in MST.  Format (ISO): YYYY-MM-ddTHH:mm:ss
 #sync.start.time=
-# The date & time to end the data pull at. Format (ISO): YYYY-MM-ddTHH:mm:ss
+# The date & time to end the data pull at. Assumed to be in MST.  Format (ISO): YYYY-MM-ddTHH:mm:ss
 #sync.end.time=
 # A comma-separated list of timeseries GUIDs to limit the data pull to
 #sync.timeseries.id.list=
+
+# One of the Logback log levels: DEBUG, ERROR, INFO, TRACE, WARN, ALL, OFF.
+# Debug starts to show the number of records retrieved and insterted, Trace even more detail.
+sync.loglevel: TRACE

--- a/src/test/java/gov/usgs/wma/gcmrc/util/TimeSeriesUtilsTest.java
+++ b/src/test/java/gov/usgs/wma/gcmrc/util/TimeSeriesUtilsTest.java
@@ -114,4 +114,19 @@ public class TimeSeriesUtilsTest {
 		testDateTime = TimeSeriesUtils.getMstDateTime(MSTDateTime);
 		assertEquals(testDateTime, LocalDateTime.from(MSTDateTime));
 	}
+	
+	@Test
+	public void getAsMstDateTimeTest() {
+		LocalDateTime dt = LocalDateTime.of(2000, 2, 2, 6, 35); //Feb 2, 2000 at 5:34 AM
+		ZonedDateTime zdt = TimeSeriesUtils.getAsMstDateTime(dt);
+		
+		assertEquals(2000, zdt.getYear());
+		assertEquals(2, zdt.getMonthValue());
+		assertEquals(2, zdt.getDayOfMonth());
+		assertEquals(6, zdt.getHour());
+		assertEquals(35, zdt.getMinute());
+		assertEquals(ZoneOffset.of("-07:00"), zdt.getOffset());
+		
+		assertNull(TimeSeriesUtils.getAsMstDateTime(null));
+	}
 }


### PR DESCRIPTION
* Fixed a bug where the user config start and end LocalDateTimes were shifted in hours to MST, resulting the actual times being different than expected.

* Added user configuration for logging, since the user needs to be able to turn on added logging to investigate issues.
* Updated example prop file w/ notes and config
* Updated to the latest released version of aqcu-data-core.  The older snapshot we had been using was no longer valid/available