### PR TITLE
GCMON-580 neverpulldatabefore confusion

### DIFF
--- a/src/main/resources/gcmrc-sync-config.properties
+++ b/src/main/resources/gcmrc-sync-config.properties
@@ -39,7 +39,17 @@ gdaws.dbName: dbName
 # to go when making the very first new data pull.  Old data can later be pulled by a
 # separate process that looks for changes / missing data.
 # If unspecified, it defaults to 30.
+
+# the "decision tree", as it were is:
+#
+#   1. Is data_processor_state.last_new_data_pull_start not null? Use that.
+#   2. if null, use default.days.to.fetch.for.new.timeseries (for now)
+#   3. compare date from default.days.to.fetch.for.new.timeseries to gdaws_aq_sync_config.neverpullbefore (if neverpullbefore is not null)
+#   4. if default.days.to.fetch.for.new.timeseries is before neverpullbefore, use neverpullbefore, but if it's not, then use date from default.days.to.fetch.for.new.timeseries
+
 default.days.to.fetch.for.new.timeseries: 30
+
+
 
 ## Specific Data Fetch Settings
 # Optional settings to pull data from a specific time range for a specific list of


### PR DESCRIPTION
GCMON-580: update config properties file with how the settings affect the date that is pulled.