### PR TITLE
GCMON-627: For old/new Jensen sites, add back the 45 minutes travel time

### DIFF
--- a/src/main/java/gov/usgs/wma/gcmrc/dao/MergeCumulativeLoadCalcDAO.java
+++ b/src/main/java/gov/usgs/wma/gcmrc/dao/MergeCumulativeLoadCalcDAO.java
@@ -32,9 +32,10 @@ public class MergeCumulativeLoadCalcDAO {
 	 * @param groupId The group_id, which should be the cumulative sand load data series
 	 * @param lastTimeStamp the last timestamp of the old site that has the final cumulative load value when the data are switched to new site
 	 * @param firstTimeStamp the first timestamp of the new site that cumulative loads are calculated
+	 * @param timeShiftMinutes the number of minutes to add to the measurement date of the new site
 	 */
 	public void calcMergeCumulativeLoadCalcToStageTable(Integer siteId, Integer newSiteId,
-			Integer sourceId, Integer groupId, String lastTimestamp, String firstTimestamp) {
+			Integer sourceId, Integer groupId, String lastTimestamp, String firstTimestamp, String timeShiftMinutes) {
 		List<TimeSeriesRecord> timeSeries = null;
 
 		Map<String, Object> params = new HashMap<String, Object>();
@@ -44,8 +45,7 @@ public class MergeCumulativeLoadCalcDAO {
 		params.put("groupId", groupId);	//for consistency, use 'groupId' as SQL param
 		params.put("lastTimestamp", lastTimestamp);
 		params.put("firstTimestamp", firstTimestamp);
-		
-		
+		params.put("timeShiftMinutes", timeShiftMinutes);
 		
 		LOG.debug("Merging cumulative loads for groupId {} for sites {} (old site) and {} (new site)", groupId, siteId, newSiteId);
 		

--- a/src/main/java/gov/usgs/wma/gcmrc/service/AutoProc.java
+++ b/src/main/java/gov/usgs/wma/gcmrc/service/AutoProc.java
@@ -175,8 +175,14 @@ public class AutoProc {
 			String lastTimestamp = mergeCumulativeLoadParams.get(siteId).get("lastTimestamp");
 			String firstTimestamp = mergeCumulativeLoadParams.get(siteId).get("firstTimestamp");
 			Integer newSiteId = Integer.parseInt(mergeCumulativeLoadParams.get(siteId).get("newSiteId"));
+			String timeShiftStr = mergeCumulativeLoadParams.get(siteId).get("timeShiftMinutes");
+			String timeShiftMinutes = "0";
+			
+			if (timeShiftStr != null) {
+				timeShiftMinutes = timeShiftStr;
+			}
 
-			mergeCumulativeLoadCalcDAO.calcMergeCumulativeLoadCalcToStageTable(siteId, newSiteId, sourceId, cumulativeLoadGroupId, lastTimestamp, firstTimestamp);
+			mergeCumulativeLoadCalcDAO.calcMergeCumulativeLoadCalcToStageTable(siteId, newSiteId, sourceId, cumulativeLoadGroupId, lastTimestamp, firstTimestamp, timeShiftMinutes);
 		}
 	}
 	

--- a/src/main/resources/mybatis/mergeCumulativeLoadCalc.xml
+++ b/src/main/resources/mybatis/mergeCumulativeLoadCalc.xml
@@ -35,7 +35,8 @@ select ts.site_id, ts.group_id, ts.measurement_date, ts.final_value, #{sourceId,
 where ts.site_id = #{siteId,jdbcType=NUMERIC} and ts.group_id = #{groupId,jdbcType=NUMERIC}
     and ts.measurement_date &lt;= to_timestamp(#{lastTimestamp,jdbcType=CHAR},'mm/dd/yyyy hh:mi:ss.ff AM')
 union
-select #{siteId,jdbcType=NUMERIC} site_id, ts.group_id, ts.measurement_date, ts.final_value + os.old_site_final final_value, 
+select #{siteId,jdbcType=NUMERIC} site_id, ts.group_id, ts.measurement_date + numtodsinterval(#{timeShiftMinutes,jdbcType=CHAR}, 'MINUTE') measurement_date,
+ ts.final_value + os.old_site_final final_value, 
 	#{sourceId,jdbcType=NUMERIC} as source_id 
 	from TIME_SERIES_STAR ts, old_site_last os
 where ts.group_id = #{groupId,jdbcType=NUMERIC} and ts.site_id = #{newSiteId,jdbcType=NUMERIC}


### PR DESCRIPTION
that was subtracted for discharge use in calculating bedload.